### PR TITLE
feat: allow hosts to refresh category

### DIFF
--- a/client/src/components/KiaTereGame.tsx
+++ b/client/src/components/KiaTereGame.tsx
@@ -147,6 +147,7 @@ const KiaTereGame: React.FC = () => {
           setActivePlayers(message.gameState.activePlayers);
           setCurrentPlayerIndex(message.gameState.currentPlayerIndex);
           setUsedLetters(new Set(message.gameState.usedLetters));
+          setCurrentCategory(message.gameState.currentCategory);
           setTimeLeft(message.gameState.timeLeft);
           setIsTimerRunning(message.gameState.isTimerRunning);
           setIsOvertimeRound(message.gameState.isOvertimeRound || false);
@@ -292,6 +293,11 @@ const KiaTereGame: React.FC = () => {
       type: 'END_TURN',
       selectedLetter,
     });
+  };
+
+  const refreshCategory = (): void => {
+    if (!isHost) return;
+    sendMessage({ type: 'REFRESH_CATEGORY' });
   };
 
   const resetGame = (): void => {
@@ -684,9 +690,19 @@ const KiaTereGame: React.FC = () => {
                   </p>
                 </div>
               )}
-              <h2 className="text-xl font-bold text-slate-800 mb-2">
-                Category
-              </h2>
+              <div className="flex items-center gap-2 mb-2">
+                <h2 className="text-xl font-bold text-slate-800">Category</h2>
+                {isHost && (
+                  <button
+                    onClick={refreshCategory}
+                    disabled={usedLetters.size > 0 || isTimerRunning}
+                    className="p-1 rounded hover:text-teal-600 disabled:text-slate-400"
+                    title="Refresh category"
+                  >
+                    <RotateCcw className="w-4 h-4" />
+                  </button>
+                )}
+              </div>
               <p
                 className={`text-2xl font-bold px-4 py-2 rounded-lg inline-block ${
                   isOvertimeRound

--- a/client/src/components/__tests__/KiaTereGame.test.tsx
+++ b/client/src/components/__tests__/KiaTereGame.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import KiaTereGame from '../KiaTereGame';
+
+const mockSendMessage = jest.fn();
+let capturedOnMessage: (msg: any) => void = () => {};
+
+jest.mock('../../hooks/useWebSocket', () => ({
+  useWebSocket: ({ onMessage }: any) => {
+    capturedOnMessage = onMessage;
+    return {
+      connectionStatus: 'connected',
+      sendMessage: mockSendMessage,
+      connect: jest.fn(),
+    };
+  },
+}));
+
+describe('KiaTereGame category refresh', () => {
+  const baseGameState = {
+    players: ['host'],
+    activePlayers: ['host'],
+    currentPlayerIndex: 0,
+    roundWins: { host: 0 },
+    currentCategory: 'Animals',
+    usedLetters: [],
+    timeLeft: 10,
+    isTimerRunning: false,
+    roundActive: true,
+    roundNumber: 1,
+    gameStarted: true,
+    difficulty: 'easy',
+    isOvertimeRound: false,
+    overtimeLevel: 0,
+    answersRequired: 1,
+  };
+
+  beforeEach(() => {
+    mockSendMessage.mockClear();
+  });
+
+  it('sends REFRESH_CATEGORY when host clicks refresh', () => {
+    render(<KiaTereGame />);
+    act(() => {
+      capturedOnMessage({
+        type: 'ROOM_CREATED',
+        roomCode: 'ABC123',
+        players: ['host'],
+        connectedPlayers: ['host'],
+      });
+      capturedOnMessage({ type: 'GAME_STARTED', gameState: baseGameState });
+    });
+
+    const button = screen.getByTitle('Refresh category');
+    fireEvent.click(button);
+
+    expect(mockSendMessage).toHaveBeenCalledWith({ type: 'REFRESH_CATEGORY' });
+  });
+
+  it('updates category on GAME_STATE_UPDATE', () => {
+    render(<KiaTereGame />);
+    act(() => {
+      capturedOnMessage({
+        type: 'ROOM_CREATED',
+        roomCode: 'ABC123',
+        players: ['host'],
+        connectedPlayers: ['host'],
+      });
+      capturedOnMessage({ type: 'GAME_STARTED', gameState: baseGameState });
+    });
+
+    expect(screen.getByText('Animals')).toBeInTheDocument();
+
+    act(() => {
+      capturedOnMessage({
+        type: 'GAME_STATE_UPDATE',
+        gameState: { ...baseGameState, currentCategory: 'Food' },
+      });
+    });
+
+    expect(screen.getByText('Food')).toBeInTheDocument();
+  });
+});

--- a/server/src/services/GameStateManager.ts
+++ b/server/src/services/GameStateManager.ts
@@ -206,6 +206,16 @@ export class GameStateManager {
     return room;
   }
 
+  refreshCategory(roomCode: string): Room | null {
+    const room = this.rooms.get(roomCode);
+    if (!room) return null;
+    if (room.gameState.usedLetters.length > 0) {
+      return null;
+    }
+    room.gameState.currentCategory = getRandomCategory();
+    return room;
+  }
+
   startTurn(roomCode: string): Room | null {
     const room = this.rooms.get(roomCode);
     if (!room) return null;

--- a/server/src/services/WebSocketServer.ts
+++ b/server/src/services/WebSocketServer.ts
@@ -116,6 +116,10 @@ export class WebSocketServer {
         this.handleSetDifficulty(ws, message);
         break;
 
+      case 'REFRESH_CATEGORY':
+        this.handleRefreshCategory(ws, message);
+        break;
+
       default:
         this.sendError(ws, 'Unknown message type');
     }
@@ -391,6 +395,25 @@ export class WebSocketServer {
     console.log(
       `Difficulty changed to ${message.difficulty} in room: ${ws.roomCode}`
     );
+  }
+
+  private handleRefreshCategory(
+    ws: ExtendedWebSocket,
+    message: WebSocketMessage
+  ): void {
+    const room = this.gameManager.getRoom(ws.roomCode!);
+    if (!room || room.host !== ws.playerName) {
+      this.sendError(ws, 'Not authorized to refresh category');
+      return;
+    }
+
+    const updatedRoom = this.gameManager.refreshCategory(ws.roomCode!);
+    if (!updatedRoom) return;
+
+    this.broadcastToRoom(ws.roomCode!, {
+      type: 'GAME_STATE_UPDATE',
+      gameState: updatedRoom.gameState,
+    });
   }
 
   public handleDisconnection(ws: ExtendedWebSocket): void {

--- a/server/src/services/__tests__/GameStateManager.test.ts
+++ b/server/src/services/__tests__/GameStateManager.test.ts
@@ -111,6 +111,22 @@ describe('GameStateManager', () => {
       });
     });
 
+    describe('Category Management', () => {
+      it('should refresh category when no letters are used', () => {
+        const initial = gameManager.getRoom(room.roomCode)!.gameState
+          .currentCategory;
+        const updatedRoom = gameManager.refreshCategory(room.roomCode);
+        expect(updatedRoom?.gameState.currentCategory).not.toBe(initial);
+      });
+
+      it('should not refresh category after letters are used', () => {
+        const testRoom = gameManager.getRoom(room.roomCode)!;
+        testRoom.gameState.usedLetters.push('A');
+        const updatedRoom = gameManager.refreshCategory(room.roomCode);
+        expect(updatedRoom).toBeNull();
+      });
+    });
+
     describe('Overtime Rounds', () => {
       beforeEach(() => {
         // Add a third player for more complex scenarios


### PR DESCRIPTION
## Summary
- let hosts reroll the room category before any letters are used
- expose `REFRESH_CATEGORY` websocket message and broadcast updates
- update client UI with refresh control and tests

## Testing
- `npm run check`
- `CI=true npm test --workspace=server`
- `CI=true npm test --workspace=client`


------
https://chatgpt.com/codex/tasks/task_e_68955c5ce91c832ca45a015af59fcae7