### PR TITLE
feat: allow custom turn duration

### DIFF
--- a/client/src/components/KiaTereGame.tsx
+++ b/client/src/components/KiaTereGame.tsx
@@ -87,6 +87,7 @@ const KiaTereGame: React.FC = () => {
   const [selectedLetter, setSelectedLetter] = useState<string | null>(null);
   const [copySuccess, setCopySuccess] = useState<boolean>(false);
   const [difficulty, setDifficulty] = useState<Difficulty>('easy');
+  const [turnTime, setTurnTime] = useState<number>(10);
   const [isCreatingRoom, setIsCreatingRoom] = useState<boolean>(false);
   const [isOvertimeRound, setIsOvertimeRound] = useState<boolean>(false);
   const [overtimeLevel, setOvertimeLevel] = useState<number>(0);
@@ -137,6 +138,7 @@ const KiaTereGame: React.FC = () => {
           setIsTimerRunning(message.gameState.isTimerRunning);
           setRoundActive(message.gameState.roundActive);
           setDifficulty(message.gameState.difficulty || 'easy');
+          setTurnTime(message.gameState.turnTime || 10);
           setIsOvertimeRound(message.gameState.isOvertimeRound || false);
           setOvertimeLevel(message.gameState.overtimeLevel || 0);
           setAnswersRequired(message.gameState.answersRequired || 1);
@@ -150,6 +152,7 @@ const KiaTereGame: React.FC = () => {
           setCurrentCategory(message.gameState.currentCategory);
           setTimeLeft(message.gameState.timeLeft);
           setIsTimerRunning(message.gameState.isTimerRunning);
+          setTurnTime(message.gameState.turnTime || turnTime);
           setIsOvertimeRound(message.gameState.isOvertimeRound || false);
           setOvertimeLevel(message.gameState.overtimeLevel || 0);
           setAnswersRequired(message.gameState.answersRequired || 1);
@@ -168,6 +171,7 @@ const KiaTereGame: React.FC = () => {
             setCurrentCategory(message.gameState.currentCategory);
             setTimeLeft(message.gameState.timeLeft);
             setIsTimerRunning(message.gameState.isTimerRunning);
+            setTurnTime(message.gameState.turnTime || turnTime);
             setRoundActive(message.gameState.roundActive);
             setIsOvertimeRound(message.gameState.isOvertimeRound);
             setOvertimeLevel(message.gameState.overtimeLevel);
@@ -184,6 +188,7 @@ const KiaTereGame: React.FC = () => {
             setCurrentCategory(message.gameState.currentCategory);
             setTimeLeft(message.gameState.timeLeft);
             setIsTimerRunning(message.gameState.isTimerRunning);
+            setTurnTime(message.gameState.turnTime || turnTime);
             setRoundActive(message.gameState.roundActive);
             setIsOvertimeRound(message.gameState.isOvertimeRound || false);
             setOvertimeLevel(message.gameState.overtimeLevel || 0);
@@ -205,7 +210,7 @@ const KiaTereGame: React.FC = () => {
           break;
       }
     },
-    []
+    [turnTime]
   );
 
   const { connectionStatus, sendMessage, connect } = useWebSocket({
@@ -267,6 +272,7 @@ const KiaTereGame: React.FC = () => {
     sendMessage({
       type: 'START_GAME',
       difficulty,
+      turnTime,
     });
   };
 
@@ -317,6 +323,7 @@ const KiaTereGame: React.FC = () => {
     setActivePlayers([]);
     setRoundNumber(1);
     setDifficulty('easy');
+    setTurnTime(10);
     setIsOvertimeRound(false);
     setOvertimeLevel(0);
     setAnswersRequired(1);
@@ -541,6 +548,23 @@ const KiaTereGame: React.FC = () => {
                   </div>
                 </div>
 
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-slate-700 mb-2">
+                    Turn Time (seconds)
+                  </label>
+                  <input
+                    type="number"
+                    min={5}
+                    max={60}
+                    value={turnTime}
+                    onChange={(e) => setTurnTime(Number(e.target.value))}
+                    className="w-full py-2 px-3 rounded-lg border border-slate-300 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                  />
+                  <div className="mt-2 text-xs text-slate-600">
+                    5-60 seconds
+                  </div>
+                </div>
+
                 <button
                   onClick={startGame}
                   disabled={
@@ -564,6 +588,7 @@ const KiaTereGame: React.FC = () => {
                   <span className="font-semibold capitalize">{difficulty}</span>
                   ({LETTER_SETS[difficulty].length} letters)
                 </p>
+                <p className="text-sm text-slate-500">Turn Time: {turnTime}s</p>
               </div>
             )}
 
@@ -832,7 +857,7 @@ const KiaTereGame: React.FC = () => {
             </p>
             <p className="text-sm">
               {isMyTurn ? "It's your turn!" : `Waiting for ${currentPlayer}...`}{' '}
-              • 10 seconds per turn
+              • {turnTime} seconds per turn
             </p>
           </div>
 

--- a/client/src/components/Lobby.tsx
+++ b/client/src/components/Lobby.tsx
@@ -12,6 +12,8 @@ export const Lobby: React.FC<LobbyProps> = ({
   copySuccess,
   onDifficultyChange,
   difficulty,
+  turnTime,
+  onTurnTimeChange,
 }) => {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
@@ -86,6 +88,24 @@ export const Lobby: React.FC<LobbyProps> = ({
                 <option value="easy">Easy (18 common letters)</option>
                 <option value="hard">Hard (All 26 letters)</option>
               </select>
+            </div>
+            <div>
+              <label
+                htmlFor="turnTime"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Turn Time (seconds)
+              </label>
+              <input
+                id="turnTime"
+                type="number"
+                min={5}
+                max={60}
+                value={turnTime}
+                onChange={(e) => onTurnTimeChange(Number(e.target.value))}
+                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                disabled={!isHost}
+              />
             </div>
           </div>
         </div>

--- a/client/src/components/__tests__/Lobby.test.tsx
+++ b/client/src/components/__tests__/Lobby.test.tsx
@@ -14,6 +14,8 @@ describe('Lobby', () => {
     copySuccess: false,
     onDifficultyChange: jest.fn(),
     difficulty: 'easy' as Difficulty,
+    turnTime: 10,
+    onTurnTimeChange: jest.fn(),
   };
 
   beforeEach(() => {
@@ -64,11 +66,27 @@ describe('Lobby', () => {
     expect(mockProps.onDifficultyChange).toHaveBeenCalledWith('hard');
   });
 
+  it('handles turn time change when host', () => {
+    render(<Lobby {...mockProps} />);
+
+    const input = screen.getByLabelText('Turn Time (seconds)');
+    fireEvent.change(input, { target: { value: '15' } });
+
+    expect(mockProps.onTurnTimeChange).toHaveBeenCalledWith(15);
+  });
+
   it('disables difficulty select when not host', () => {
     render(<Lobby {...mockProps} isHost={false} />);
 
     const select = screen.getByLabelText('Difficulty');
     expect(select).toBeDisabled();
+  });
+
+  it('disables turn time input when not host', () => {
+    render(<Lobby {...mockProps} isHost={false} />);
+
+    const input = screen.getByLabelText('Turn Time (seconds)');
+    expect(input).toBeDisabled();
   });
 
   it('shows start game button only when host', () => {
@@ -150,6 +168,7 @@ describe('Lobby', () => {
         onStartGame: jest.fn(),
         onCopyCode: jest.fn(),
         onDifficultyChange: jest.fn(),
+        onTurnTimeChange: jest.fn(),
       };
 
       expect(() => render(<Lobby {...propsWithoutCallbacks} />)).not.toThrow();

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -20,6 +20,7 @@ export interface GameState {
   isOvertimeRound: boolean;
   overtimeLevel: number;
   answersRequired: number;
+  turnTime: number;
 }
 
 export interface WebSocketMessage {
@@ -58,6 +59,8 @@ export interface LobbyProps {
   copySuccess: boolean;
   onDifficultyChange: (difficulty: Difficulty) => void;
   difficulty: Difficulty;
+  turnTime: number;
+  onTurnTimeChange: (turnTime: number) => void;
 }
 
 export interface GameBoardProps {

--- a/server/src/services/GameStateManager.ts
+++ b/server/src/services/GameStateManager.ts
@@ -201,12 +201,16 @@ export class GameStateManager {
   }
 
   // Game state management
-  startGame(roomCode: string, difficulty: Difficulty = 'easy'): Room | null {
+  startGame(
+    roomCode: string,
+    difficulty: Difficulty = 'easy',
+    turnTime: number = GAME_CONSTANTS.TURN_TIME
+  ): Room | null {
     const room = this.rooms.get(roomCode);
     if (!room) return null;
 
     // Initialize game state
-    room.gameState = createInitialGameState(room.players);
+    room.gameState = createInitialGameState(room.players, turnTime);
     room.gameState.gameStarted = true;
     room.gameState.roundActive = true;
     room.gameState.currentCategory = this.selectCategory(room);
@@ -233,7 +237,7 @@ export class GameStateManager {
     if (!room) return null;
 
     room.gameState.isTimerRunning = true;
-    room.gameState.timeLeft = GAME_CONSTANTS.TURN_TIME;
+    room.gameState.timeLeft = room.gameState.turnTime;
 
     // Start the server-side timer
     this.startServerTimer(roomCode);
@@ -266,7 +270,7 @@ export class GameStateManager {
       (room.gameState.currentPlayerIndex + 1) %
       room.gameState.activePlayers.length;
 
-    room.gameState.timeLeft = GAME_CONSTANTS.TURN_TIME;
+    room.gameState.timeLeft = room.gameState.turnTime;
     room.gameState.isTimerRunning = true;
 
     // Start timer for next player
@@ -310,7 +314,7 @@ export class GameStateManager {
     }
 
     // Continue with next player - fresh timer
-    room.gameState.timeLeft = GAME_CONSTANTS.TURN_TIME;
+    room.gameState.timeLeft = room.gameState.turnTime;
     room.gameState.isTimerRunning = true;
 
     return { type: 'continue', room };
@@ -350,7 +354,7 @@ export class GameStateManager {
     room.gameState.activePlayers = [...room.gameState.players];
     room.gameState.currentPlayerIndex = nextPlayerIndex; // Start with next player, not 0
     room.gameState.usedLetters = [];
-    room.gameState.timeLeft = GAME_CONSTANTS.TURN_TIME;
+    room.gameState.timeLeft = room.gameState.turnTime;
     room.gameState.isTimerRunning = false; // Timer not running yet - player needs to start turn
     room.gameState.roundActive = true; // Keep this TRUE for new round
     room.gameState.currentCategory = this.selectCategory(room);
@@ -390,7 +394,7 @@ export class GameStateManager {
 
     // Reset timer and start with first player
     room.gameState.currentPlayerIndex = 0;
-    room.gameState.timeLeft = GAME_CONSTANTS.TURN_TIME;
+    room.gameState.timeLeft = room.gameState.turnTime;
     room.gameState.isTimerRunning = false; // Player needs to start turn
 
     return { type: 'overtimeStart', room };

--- a/server/src/services/WebSocketServer.ts
+++ b/server/src/services/WebSocketServer.ts
@@ -2,6 +2,7 @@ import WebSocket from 'ws';
 import { createServer } from 'http';
 import { ExtendedWebSocket, WebSocketMessage } from '../types';
 import { GameStateManager } from './GameStateManager';
+import { GAME_CONSTANTS } from '../constants';
 
 export class WebSocketServer {
   private port?: number;
@@ -210,7 +211,15 @@ export class WebSocketServer {
     }
 
     const difficulty = message.difficulty || 'easy';
-    const updatedRoom = this.gameManager.startGame(ws.roomCode!, difficulty);
+    const turnTime =
+      typeof message.turnTime === 'number'
+        ? message.turnTime
+        : GAME_CONSTANTS.TURN_TIME;
+    const updatedRoom = this.gameManager.startGame(
+      ws.roomCode!,
+      difficulty,
+      turnTime
+    );
 
     if (!updatedRoom) {
       this.sendError(ws, 'Failed to start game');

--- a/server/src/services/__tests__/WebSocketServer.test.ts
+++ b/server/src/services/__tests__/WebSocketServer.test.ts
@@ -185,6 +185,36 @@ describe('WebSocketServer', () => {
     });
   });
 
+  it('should start game with custom turn time', () => {
+    const createMessage: WebSocketMessage = {
+      type: 'CREATE_ROOM',
+      playerName: 'host',
+    };
+    server.handleMessage(mockWs as any, createMessage);
+    const customRoomCode = mockWs.messages[0].roomCode;
+
+    const joinMessage: WebSocketMessage = {
+      type: 'JOIN_ROOM',
+      roomCode: customRoomCode,
+      playerName: 'player1',
+    };
+    server.handleMessage(joinWs as any, joinMessage);
+
+    const startMessage: WebSocketMessage = {
+      type: 'START_GAME',
+      roomCode: customRoomCode,
+      playerName: 'host',
+      turnTime: 15,
+    };
+    server.handleMessage(mockWs as any, startMessage);
+
+    const gameStarted = mockWs.messages.find(
+      (msg) => msg.type === 'GAME_STARTED'
+    );
+    expect(gameStarted?.gameState.turnTime).toBe(15);
+    expect(gameStarted?.gameState.timeLeft).toBe(15);
+  });
+
   describe('Error Handling', () => {
     it('should handle missing required fields', () => {
       const invalidMessage: WebSocketMessage = {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -28,6 +28,7 @@ export interface GameState {
   isOvertimeRound: boolean;
   overtimeLevel: number;
   answersRequired: number;
+  turnTime: number;
 }
 
 export interface WebSocketMessage {

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -25,6 +25,7 @@ export interface GameState {
   roundNumber: number;
   gameStarted: boolean;
   difficulty: Difficulty;
+  turnTime: number;
 }
 
 export interface WebSocketMessage {

--- a/server/src/utils/roomUtils.ts
+++ b/server/src/utils/roomUtils.ts
@@ -16,7 +16,10 @@ export function generateRoomCode(): string {
 /**
  * Creates the initial game state for a new game with the given players.
  */
-export function createInitialGameState(players: string[]): GameState {
+export function createInitialGameState(
+  players: string[],
+  turnTime: number = GAME_CONSTANTS.TURN_TIME
+): GameState {
   const roundWins: Record<string, number> = {};
   const playersCopy = [...players];
   playersCopy.forEach((player) => (roundWins[player] = 0));
@@ -29,7 +32,7 @@ export function createInitialGameState(players: string[]): GameState {
     currentCategory: '',
     usedLetters: [],
     usedCategories: [],
-    timeLeft: GAME_CONSTANTS.TURN_TIME,
+    timeLeft: turnTime,
     isTimerRunning: false,
     roundActive: false,
     roundNumber: 1,
@@ -38,6 +41,7 @@ export function createInitialGameState(players: string[]): GameState {
     isOvertimeRound: false,
     overtimeLevel: 0,
     answersRequired: 1,
+    turnTime,
   };
 }
 


### PR DESCRIPTION
## Summary
- allow game host to customize turn time before starting a game
- propagate chosen turn time through WebSocket messages and server game state
- cover custom turn time with tests

## Testing
- `npm run check`
- `cd client && npm test --silent`
- `cd server && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68964c5f1548832c8089f5da64fe59dd