### PR TITLE
feat: add keyboard controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A fast-paced multiplayer word game where players race against time to find words
 - ⚡ **10-Second Turns** - Fast-paced gameplay keeps everyone engaged
 - 🏆 **Score Tracking** - First to win 3 rounds wins the game
 - 🎨 **Modern UI** - Clean, professional design with TypeScript
+- ⌨️ **Keyboard Controls** - Play using letter keys and Enter
 
 ## 🎮 How to Play
 
@@ -26,9 +27,9 @@ A fast-paced multiplayer word game where players race against time to find words
 ### Gameplay
 1. **Category Challenge**: Each round has a category (Animals, Foods, Countries, etc.)
 2. **Your Turn**: You have 10 seconds to find a word that fits the category
-3. **Select Letter**: Choose the starting letter of your word
+3. **Select Letter**: Choose the starting letter by clicking or typing it
 4. **Say Your Word**: Announce your word out loud to other players
-5. **End Turn**: Click "End Turn" to pass to the next player
+5. **End Turn**: Press Enter or click "End Turn" to pass to the next player
 6. **Elimination**: If time runs out, you're eliminated from the round
 
 ### Winning

--- a/client/src/components/GameBoard.tsx
+++ b/client/src/components/GameBoard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Clock, Trophy } from 'lucide-react';
 import { GameBoardProps } from '../types';
 
@@ -14,6 +14,22 @@ export const GameBoard: React.FC<GameBoardProps> = ({
   roundNumber,
   roundWins,
 }) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      const key = event.key.toUpperCase();
+      if (
+        letters.includes(key) &&
+        !usedLetters.has(key) &&
+        isCurrentPlayer &&
+        isTimerRunning
+      ) {
+        onLetterSelect(key);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [letters, usedLetters, isCurrentPlayer, isTimerRunning, onLetterSelect]);
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
       <div className="w-full max-w-4xl bg-white rounded-lg shadow-md p-6">

--- a/client/src/components/KiaTereGame.tsx
+++ b/client/src/components/KiaTereGame.tsx
@@ -295,34 +295,51 @@ const KiaTereGame: React.FC = () => {
     });
   };
 
-  const handleLetterSelect = (letter: string): void => {
-    if (!roundActive || usedLetters.has(letter) || !isTimerRunning) return;
-    if (activePlayers[currentPlayerIndex] !== playerName) return;
+  const handleLetterSelect = useCallback(
+    (letter: string): void => {
+      if (!roundActive || usedLetters.has(letter) || !isTimerRunning) return;
+      if (activePlayers[currentPlayerIndex] !== playerName) return;
 
-    // Toggle letter selection
-    const newSelectedLetter = selectedLetter === letter ? null : letter;
-    setSelectedLetter(newSelectedLetter);
-    sendMessage({
-      type: 'PLAYER_SELECTED_LETTER',
-      letter: newSelectedLetter,
-    });
-  };
+      const newSelectedLetter = selectedLetter === letter ? null : letter;
+      setSelectedLetter(newSelectedLetter);
+      sendMessage({
+        type: 'PLAYER_SELECTED_LETTER',
+        letter: newSelectedLetter,
+      });
+    },
+    [
+      roundActive,
+      usedLetters,
+      isTimerRunning,
+      activePlayers,
+      currentPlayerIndex,
+      playerName,
+      selectedLetter,
+      sendMessage,
+    ]
+  );
 
-  const startTurn = (): void => {
+  const startTurn = useCallback((): void => {
     if (activePlayers[currentPlayerIndex] !== playerName) return;
     sendMessage({
       type: 'START_TURN',
     });
-  };
+  }, [activePlayers, currentPlayerIndex, playerName, sendMessage]);
 
-  const endTurn = (): void => {
+  const endTurn = useCallback((): void => {
     if (!selectedLetter || activePlayers[currentPlayerIndex] !== playerName)
       return;
     sendMessage({
       type: 'END_TURN',
       selectedLetter,
     });
-  };
+  }, [
+    selectedLetter,
+    activePlayers,
+    currentPlayerIndex,
+    playerName,
+    sendMessage,
+  ]);
 
   const refreshCategory = (): void => {
     if (!isHost) return;
@@ -370,6 +387,40 @@ const KiaTereGame: React.FC = () => {
       setTimeout(() => setCopySuccess(false), 2000);
     }
   };
+
+  const currentPlayer =
+    activePlayers && activePlayers.length > 0
+      ? activePlayers[currentPlayerIndex] || activePlayers[0]
+      : players[0] || 'Unknown';
+  const isMyTurn = currentPlayer === playerName && currentPlayer !== 'Unknown';
+
+  useEffect(() => {
+    if (gameState !== 'playing') return;
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (['INPUT', 'TEXTAREA'].includes((event.target as HTMLElement).tagName))
+        return;
+      const key = event.key.toUpperCase();
+      if (letters.includes(key)) {
+        handleLetterSelect(key);
+      } else if (event.key === 'Enter' && isMyTurn) {
+        if (roundActive) {
+          endTurn();
+        } else {
+          startTurn();
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [
+    gameState,
+    letters,
+    handleLetterSelect,
+    isMyTurn,
+    roundActive,
+    startTurn,
+    endTurn,
+  ]);
 
   // Main Menu
   if (gameState === 'menu') {
@@ -652,12 +703,6 @@ const KiaTereGame: React.FC = () => {
     );
   }
 
-  const currentPlayer =
-    activePlayers && activePlayers.length > 0
-      ? activePlayers[currentPlayerIndex] || activePlayers[0]
-      : players[0] || 'Unknown';
-  const isMyTurn = currentPlayer === playerName && currentPlayer !== 'Unknown';
-
   // Playing Game
   return (
     <div className="min-h-screen bg-slate-50 p-4" data-testid="game-playing">
@@ -874,8 +919,8 @@ const KiaTereGame: React.FC = () => {
           {/* Instructions */}
           <div className="text-center mt-8 text-slate-600">
             <p className="mb-2">
-              1. Select/deselect letters to plan your word • 2. Say your word •
-              3. Click "End Turn"
+              1. Select/deselect letters with your keyboard or mouse • 2. Say
+              your word • 3. Press Enter or click "End Turn"
             </p>
             <p className="text-sm">
               {isMyTurn ? "It's your turn!" : `Waiting for ${currentPlayer}...`}{' '}

--- a/client/src/components/__tests__/GameBoard.test.tsx
+++ b/client/src/components/__tests__/GameBoard.test.tsx
@@ -60,6 +60,14 @@ describe('GameBoard', () => {
     expect(mockProps.onLetterSelect).toHaveBeenCalledWith('C');
   });
 
+  it('handles letter selection via keyboard', () => {
+    render(<GameBoard {...mockProps} />);
+
+    fireEvent.keyDown(window, { key: 'c' });
+
+    expect(mockProps.onLetterSelect).toHaveBeenCalledWith('C');
+  });
+
   it('disables used letters', () => {
     render(<GameBoard {...mockProps} />);
 


### PR DESCRIPTION
## Summary
- enable selecting letters via keyboard
- allow starting or ending turns with Enter
- document keyboard shortcuts

## Testing
- `npm test`
- `npm run lint:check`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689727a25034832cb474aeb4ef731412